### PR TITLE
Bump build number for long prefix packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - disable-failing-tests.patch
 
 build:
-  number: 2
+  number: 3
   features:
     - vc9               # [win and py27]
     - vc10              # [win and py34]


### PR DESCRIPTION
Bumps the build number to upload the long prefix packages created by PR ( https://github.com/conda-forge/pyside-feedstock/pull/11 ).

cc @jjhelmus